### PR TITLE
Fix off-by-one error in square drawing

### DIFF
--- a/lib/ruby_identicon.rb
+++ b/lib/ruby_identicon.rb
@@ -120,11 +120,11 @@ module RubyIdenticon
         y = options[:border_size] + (sqy * options[:square_size])
 
         # left hand side
-        png.rect(x, y, x + options[:square_size], y + options[:square_size], color, color)
+        png.rect(x, y, x + options[:square_size] - 1, y + options[:square_size] - 1, color, color)
 
         # mirror right hand side
         x = options[:border_size] + ((options[:grid_size] - 1 - sqx) * options[:square_size])
-        png.rect(x, y, x + options[:square_size], y + options[:square_size], color, color)
+        png.rect(x, y, x + options[:square_size] - 1, y + options[:square_size] - 1, color, color)
       end
 
       hash >>= 1


### PR DESCRIPTION
Squares were 1 pixel too big on each side, as ChunkyPNG's #rect() method's
x1 and y1 arguments are inclusive. This could be noticed in cases where
squares were forming a chessboard pattern and their corners there were
clearly overlapping.