### PR TITLE
Add base64 as explicit dependency

### DIFF
--- a/ruby_identicon.gemspec
+++ b/ruby_identicon.gemspec
@@ -36,5 +36,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.10.0"
   spec.add_development_dependency "yard", ">= 0.9.20"
 
+  spec.add_dependency "base64", "~> 0.2.0"
   spec.add_dependency "chunky_png", "~> 1.4.0"
 end


### PR DESCRIPTION
Starting with ruby 3.4, `base64` will no longer be packaged inside the standard library. This means we need to explicitly list it as a dependency.